### PR TITLE
Update outer-wilds-alpha.svelte

### DIFF
--- a/src/routes/outer-wilds-alpha.svelte
+++ b/src/routes/outer-wilds-alpha.svelte
@@ -30,8 +30,12 @@
 		}
 	];
 	
-	const alphaMods = [
-		
+	const alphaMods = [		
+		{
+			name: 'AlphaFixes',
+			description: 'Fixes some issues with the alpha.',
+			href: 'https://github.com/ShoosGun/AlphaFixes',
+		},
 		{
 			name: 'Navinha',
 			description: 'Adds a small custom ship into the game.',


### PR DESCRIPTION
Added the [AlphaFixes](https://github.com/ShoosGun/AlphaFixes) to the website. I know we are going to change it to a proper database, but if someone is running the game with a computer that can run the game at <120 fps, the inputs will break, and this mod helps fixing that issue. So in the meantime, if someone wants to play the alpha, but is having this problem, they can go to the website and find this plugin.