### PR TITLE
Show addons of utility mods in standard mods list

### DIFF
--- a/src/routes/mods/index.svelte
+++ b/src/routes/mods/index.svelte
@@ -6,8 +6,9 @@
 	import { modList } from '$lib/store';
 	import SortedModGrid from '$lib/components/sorted-mod-grid.svelte';
 
-	const standardMods = $modList.filter((mod) => !mod.utility && !mod.parent && !mod.alpha);
 	const utilityMods = $modList.filter((mod) => mod.utility && !mod.parent && !mod.alpha);
+	const utilityModsUniqueNames = utilityMods.map((mod) => mod.uniqueName);
+	const standardMods = $modList.filter((mod) => !mod.utility && (!mod.parent || utilityModsUniqueNames.includes(mod.parent)) && !mod.alpha);
 </script>
 
 <svelte:head>

--- a/src/routes/outer-wilds-alpha.svelte
+++ b/src/routes/outer-wilds-alpha.svelte
@@ -8,8 +8,9 @@
 	import SortedModGrid from '$lib/components/sorted-mod-grid.svelte';
 	import { modList } from '$lib/store';
 
-	const standardMods = $modList.filter((mod) => !mod.utility && !mod.parent && mod.alpha);
 	const utilityMods = $modList.filter((mod) => mod.utility && !mod.parent && mod.alpha);
+	const utilityModsUniqueNames = utilityMods.map((mod) => mod.uniqueName);
+	const standardMods = $modList.filter((mod) => !mod.utility && (!mod.parent || utilityModsUniqueNames.includes(mod.parent)) && mod.alpha);
 </script>
 
 <svelte:head>


### PR DESCRIPTION
This case was discussed for the Slate's Shipyard mods that the developer wants to make addons of it so they are displayed in the dropdown in the mod manager but without losing visibility in outerwilds.com.

Tested with a fake db copy of the original one but making Spaceshipinha and Car Example addons of Slate's Shipyard:
https://gist.githubusercontent.com/dgarroDC/dc57a996f8c7c1c03f27598ae548f776/raw/932f9d7c6c5609ca820c88284afeaf9183a3675a/fake-ow-db.json

Made the change in both the regular and alpha mods indices for consistency.

Before:
![before](https://user-images.githubusercontent.com/22490080/191371289-f2514de2-cc22-4945-b034-1515f6c05439.png)

After:
![after](https://user-images.githubusercontent.com/22490080/191371085-044925bc-2061-4ada-b44f-aa1f35a72681.png)
