### PR TITLE
Sort hot mods by install count

### DIFF
--- a/src/lib/components/sorted-mod-grid.svelte
+++ b/src/lib/components/sorted-mod-grid.svelte
@@ -14,8 +14,9 @@
 	import { onMount } from 'svelte';
 
 	export let mods: ModsRequestItem[] = [];
+	export let defaultSortOrder: SortOrder = 'hot';
 
-	let sortOrder: SortOrder = 'hot';
+	let sortOrder: SortOrder = defaultSortOrder;
 	let filter = '';
 	let filteredMods: ModsRequestItem[] = mods;
 

--- a/src/lib/helpers/api/get-download-history.ts
+++ b/src/lib/helpers/api/get-download-history.ts
@@ -89,12 +89,3 @@ function lowerCaseKeys<TValue>(record: Record<string, TValue>) {
 function filterHistoryPoint(historyPoint: HistoryPoint | undefined): historyPoint is HistoryPoint {
 	return (historyPoint?.DownloadCount ?? 0) > 0;
 }
-
-export async function tryGedModDownloadHistory(modUniqueName: string) {
-	try {
-		return await getModDownloadHistory(modUniqueName);
-	} catch (error) {
-		console.warn(`Failed to get download history for ${modUniqueName}. ${error}`);
-		return [];
-	}
-}

--- a/src/lib/helpers/api/get-mod-database.ts
+++ b/src/lib/helpers/api/get-mod-database.ts
@@ -12,6 +12,7 @@ export type Mod = {
 	repo: string;
 	downloadUrl: string;
 	downloadCount: number;
+	installCount: number;
 	viewCount: number;
 	latestReleaseDate: string;
 	firstReleaseDate: string;

--- a/src/lib/helpers/api/history-points.ts
+++ b/src/lib/helpers/api/history-points.ts
@@ -72,32 +72,3 @@ export const getDateText = (historyPoint: HistoryPoint) =>
 		month: 'short',
 		year: 'numeric',
 	});
-
-const getHistoryPointsSinceDaysAgo = (
-	historyPoints: HistoryPoint[],
-	daysAgo: number
-): [HistoryPoint?, HistoryPoint?] => {
-	const startDate = new Date();
-	startDate.setDate(startDate.getDate() - daysAgo);
-
-	// historyPoints is in reverse chronological order.
-	let rangeStartIndex = historyPoints.findIndex(
-		(historyPoint) => getDate(historyPoint) < startDate
-	);
-
-	if (rangeStartIndex == -1) rangeStartIndex = historyPoints.length;
-
-	if (rangeStartIndex <= 0) return [];
-
-	return [historyPoints[rangeStartIndex], historyPoints[0]];
-};
-
-export const getDownloadCountSinceDaysAgo = (historyPoints: HistoryPoint[], daysAgo: number) => {
-	const pointsSinceDaysAgo = getHistoryPointsSinceDaysAgo(historyPoints, daysAgo);
-
-	const firstCount = pointsSinceDaysAgo[0]?.DownloadCount ?? 0;
-
-	const lastCount = pointsSinceDaysAgo[1]?.DownloadCount ?? 0;
-
-	return lastCount - firstCount;
-};

--- a/src/lib/helpers/constants.ts
+++ b/src/lib/helpers/constants.ts
@@ -5,5 +5,4 @@ export const listedImageSize = {
 
 export const websiteUrl = 'https://outerwildsmods.com';
 
-export const recentDownloadsDayCount = 60;
 export const recentViewsDayCount = 30;

--- a/src/lib/helpers/mod-sorting.ts
+++ b/src/lib/helpers/mod-sorting.ts
@@ -1,5 +1,5 @@
 import type { ModsRequestItem } from '../../routes/api/mods.json';
-import { recentDownloadsDayCount } from './constants';
+import { recentDownloadsDayCount, recentViewsDayCount } from './constants';
 
 export const sortOrderParamName = 'sortOrder' as const;
 
@@ -19,6 +19,12 @@ export const sortOrders = {
 		title: `Recent downloads (${recentDownloadsDayCount} days)`,
 		compareFunction: (modA: ModsRequestItem, modB: ModsRequestItem) => {
 			return modB.recentDownloads - modA.recentDownloads;
+		},
+	},
+	mostViewsXDays: {
+		title: `Recent views (${recentViewsDayCount} days)`,
+		compareFunction: (modA: ModsRequestItem, modB: ModsRequestItem) => {
+			return modB.viewCount - modA.viewCount;
 		},
 	},
 	newest: {

--- a/src/lib/helpers/mod-sorting.ts
+++ b/src/lib/helpers/mod-sorting.ts
@@ -7,7 +7,7 @@ export const sortOrders = {
 	hot: {
 		title: 'Hot',
 		compareFunction: (modA: ModsRequestItem, modB: ModsRequestItem) => {
-			return modB.viewCount - modA.viewCount;
+			return modB.installCount - modA.installCount;
 		},
 	},
 	mostDownloaded: {

--- a/src/lib/helpers/mod-sorting.ts
+++ b/src/lib/helpers/mod-sorting.ts
@@ -15,12 +15,6 @@ export const sortOrders = {
 		compareFunction: (modA: ModsRequestItem, modB: ModsRequestItem) =>
 			modB.downloadCount - modA.downloadCount,
 	},
-	mostDownloadedXDays: {
-		title: `Recent downloads (${recentDownloadsDayCount} days)`,
-		compareFunction: (modA: ModsRequestItem, modB: ModsRequestItem) => {
-			return modB.recentDownloads - modA.recentDownloads;
-		},
-	},
 	mostViewsXDays: {
 		title: `Recent views (${recentViewsDayCount} days)`,
 		compareFunction: (modA: ModsRequestItem, modB: ModsRequestItem) => {

--- a/src/routes/api/mods.json.ts
+++ b/src/routes/api/mods.json.ts
@@ -9,8 +9,6 @@ import { getModThumbnail } from '$lib/helpers/api/get-mod-thumbnail';
 import { getImageMap } from '$lib/helpers/api/get-image-map';
 import { modList } from '$lib/store';
 import { readFromStore } from '$lib/helpers/read-from-store';
-import { tryGedModDownloadHistory } from '$lib/helpers/api/get-download-history';
-import { getDownloadCountSinceDaysAgo } from '$lib/helpers/api/history-points';
 
 const supportedTypes: (keyof sharp.FormatEnum)[] = [
 	'png',
@@ -28,7 +26,6 @@ export interface ModsRequestItem extends Mod {
 	openGraphImageUrl: string | null;
 	formattedDownloadCount: string;
 	rawContentUrl: string | null;
-	recentDownloads: number;
 }
 
 export const get: RequestHandler = async () => {
@@ -55,12 +52,6 @@ export const get: RequestHandler = async () => {
 			const rawContentUrl = getRawContentUrl(mod);
 			let imageUrl: string | null = null;
 			let openGraphImageUrl: string | null = null;
-
-			const downloadHistory = await tryGedModDownloadHistory(mod.uniqueName);
-			const recentDownloads = getDownloadCountSinceDaysAgo(
-				downloadHistory,
-				recentDownloadsDayCount
-			);
 
 			try {
 				const thumbnail = await getModThumbnail(mod);
@@ -90,7 +81,6 @@ export const get: RequestHandler = async () => {
 				openGraphImageUrl,
 				formattedDownloadCount: formatNumber(mod.downloadCount),
 				rawContentUrl,
-				recentDownloads,
 			};
 		})
 	);

--- a/src/routes/mods/[mod]/downloads.svelte
+++ b/src/routes/mods/[mod]/downloads.svelte
@@ -102,9 +102,6 @@
 					{/each}
 				</select>
 			</div>
-			<div class="mb-4">
-				Downloads in the last {recentDownloadsDayCount} days: {mod.recentDownloads}
-			</div>
 		</div>
 		<DownloadsChart
 			historyPoints={modDownloadHistory}

--- a/src/routes/mods/[mod]/downloads.svelte
+++ b/src/routes/mods/[mod]/downloads.svelte
@@ -49,7 +49,7 @@
 	import { getModPathName } from '$lib/helpers/mod-path-name';
 	import { modList } from '$lib/store';
 	import type { HistoryPoint } from '$lib/helpers/api/history-points';
-	import { recentDownloadsDayCount, recentViewsDayCount } from '$lib/helpers/constants';
+	import { recentDownloadsDayCount } from '$lib/helpers/constants';
 
 	export let modDownloadHistory: HistoryPoint[] = [];
 	export let mod: ModsRequestItem;

--- a/src/routes/mods/index.svelte
+++ b/src/routes/mods/index.svelte
@@ -26,6 +26,6 @@
 		<p>
 			These aren't usually useful by themselves, but contain common resources used by other mods.
 		</p>
-		<SortedModGrid mods={utilityMods} />
+		<SortedModGrid mods={utilityMods} defaultSortOrder='mostDownloadedXDays' />
 	</PageSection>
 </PageLayout>

--- a/src/routes/mods/index.svelte
+++ b/src/routes/mods/index.svelte
@@ -26,6 +26,6 @@
 		<p>
 			These aren't usually useful by themselves, but contain common resources used by other mods.
 		</p>
-		<SortedModGrid mods={utilityMods} defaultSortOrder='mostDownloadedXDays' />
+		<SortedModGrid mods={utilityMods} defaultSortOrder='mostViewsXDays' />
 	</PageSection>
 </PageLayout>

--- a/src/routes/outer-wilds-alpha.svelte
+++ b/src/routes/outer-wilds-alpha.svelte
@@ -50,6 +50,6 @@
 		<p>
 			These aren't usually useful by themselves, but contain common resources used by other mods.
 		</p>
-		<SortedModGrid mods={utilityMods} />
+		<SortedModGrid mods={utilityMods} defaultSortOrder='mostDownloadedXDays' />
 	</PageSection>
 </PageLayout>

--- a/src/routes/outer-wilds-alpha.svelte
+++ b/src/routes/outer-wilds-alpha.svelte
@@ -50,6 +50,6 @@
 		<p>
 			These aren't usually useful by themselves, but contain common resources used by other mods.
 		</p>
-		<SortedModGrid mods={utilityMods} defaultSortOrder='mostDownloadedXDays' />
+		<SortedModGrid mods={utilityMods} defaultSortOrder='mostViewsXDays' />
 	</PageSection>
 </PageLayout>


### PR DESCRIPTION
Use the `installCount` property from the [database](https://github.com/ow-mods/ow-mod-db/blob/7204547a139bb8f2d684630e797e907ea75c08f2/fetch-mods/get-install-counts.ts) (new installs from the [mod manager](https://github.com/ow-mods/ow-mod-manager/blob/ea9cece5c0cea7320f0835661a0caf32ed7c36cf/app/services/mods.ts#L94) in the last 30 days) to sort hot mods.

Also added the previous hot order (recent views) as another sort option and change the default sort order of utility mod sections to recent downloads instead of hot (recent installs).

Edit: Since the recent downloads order is somehow unstable, I removed that sort order, utility mods are sorted by recent views by default now (previous hot). This closes #50 