### PR TITLE
feat(i18n): add i18n support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "i18n-ally.localesPaths": [
+    "locales"
+  ],
+  "i18n-ally.keystyle": "nested"
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ If you notice the website is down, please notify the admins in the [Outer Wilds 
 - Run `pnpm run dev`;
 - Server will run in localhost.
 
+## Localization
+
+When writing locales (in the `locales` folder), use `{...}` to interpolate variables. For example, `You have {n} apples` will be translated to `Você tem {n} maçãs` in Portuguese, and `Tu as {n} .pommes` in French.
+
+`text.1`, `text.2` represent parts of the text that are cut by elements on the page. You don't need to add spaces to the beginning/end of those. See the english file for examples.
+
+See [the svelte-i18n docs](https://github.com/kaisermann/svelte-i18n/blob/main/docs/Formatting.md) for more info.
+
 ## Testing changes
 
 Before deploying changes live, it's a good idea to test them on the [staging website](https://github.com/ow-mods/staging.outerwildsmods.com). Just push to the master branch of the staging repo and changes will be deployed to [staging.outerwildsmods.com](https://staging.outerwildsmods.com). These two repos aren't kept automatically in sync, so one thing you can do is develop on a new branch in the `outerwildsmods.com` repo, and then use this command to force-push the changes to the staging repo:

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,283 @@
+{
+  "404": {
+    "title": "Not Found - Outer Wilds Mods",
+    "description": "Something went wrong on the Outer Wilds Mods website"
+  },
+  "general": {
+    "websitename": "Outer Wilds Mods",
+    "outerwilds": "Outer Wilds",
+    "modmanager": "Mod Manager",
+    "newhorizons": "New Horizons",
+    "newhorizons-docs": "New Horizons Docs",
+    "newhorizons-template": "New Horizons Addon Template",
+    "steam": "Steam",
+    "epicgames": "Epic"
+  },
+  "main": {
+    "header": {
+      "title": "Outer Wilds Mods - Download and Install Mods for Outer Wilds",
+      "description": "Find all the tools needed to mod Outer Wilds. Download and install mods with the Outer Wilds Mod Manager."
+    },
+    "body": {
+      "hero": {
+        "1": "are unofficial modifications for",
+        "2": ", which add new features, improvements, extra content, and more. Use the",
+        "3": "to easily download and install these mods. There are currently a total of {modList.length} mods, addons, and utilities."
+      },
+      "mods": {
+        "title": "Some of our mods",
+        "cols": {
+          "hot": "Hot Mods",
+          "new": "New Mods",
+          "update": "Recetly Updated"
+        }
+      },
+      "support": {
+        "title": "Support and modding talk",
+        "description": "Join our Discord server if you need support, wanna learn about making mods, or just to chat with this wonderful modding community:"
+      },
+      "become": {
+        "title": "Become a modder",
+        "description": "If you want to make your own mods, the OWML documentation has most of the info you need to get started. The easiest way to start is by cloning the mod template project and following the instructions there. Also, that Discord server linked above is full of people who will help you.",
+        "links": {
+          "owml": "Read the OWML docs to learn how to make mods",
+          "template": "Outer Wilds mod template"
+        }
+      },
+      "newhorizons": {
+        "title": "Create custom content with New Horizons",
+        "description": {
+          "1": "With",
+          "2": ", you can create new planets and edit existing ones. Create new stories with character dialogue, translatable text, ship log entries, etc. You can make custom content without any coding knowledge, but you can also add your own code to further improve your creations."
+        },
+        "links": {
+          "docs": "Read the New Horizons docs"
+        }
+      },
+      "outerwilds": {
+        "title-questionmark": "?",
+        "description": "Outer Wilds is a neat game. Check it out and buy it or whatever.",
+        "links": {
+          "website": "Official website"
+        }
+      }
+    }
+  },
+  "error": {
+    "title": "Error - Outer Wilds Mods",
+    "description": "Something went wrong on the Outer Wilds Mods website"
+  },
+  "history": {
+    "timeline": {
+      "bigbang": "The Big Bang",
+      "spaceworthy": "Spaceworthy",
+      "alpha": "Outer Wilds Alpha",
+      "release": "Outer Wilds released",
+      "taimatem": "TAImatem joins",
+      "alek": "Alek joins",
+      "owml": "First OWML release",
+      "_nebula": "_nebula joins",
+      "nexusmods": "Nexus Mods page created",
+      "raicuparta": "Raicuparta joins",
+      "nomaivr": "First NomaiVR release",
+      "logan-email": "Logan emails",
+      "qsb": "First QSB release",
+      "modders-join": "Modders join OWML team",
+      "marshmallow": "Marshmallow",
+      "modmanager": "Mod manager",
+      "moddatabase": "Mod database",
+      "modswebsite": "Mods website",
+      "alpha-modding": "Alpha modding",
+      "eotw-leak": "DLC leak",
+      "eotw-announce": "DLC announced",
+      "johncorby": "JohnCorby",
+      "logan-discord": "Logan joins Discord",
+      "eotw-release": "DLC releases",
+      "xen": "Xen",
+      "newhorizons": "New Horizons",
+      "discord": "Modding Discord server",
+      "present": "Present",
+      "universe-death": "Heat death of the Universe",
+      "controls": {
+        "previous": "Previous",
+        "next": "Next",
+        "transitions-time": "Transitions: ",
+        "scale": "Scale: ",
+        "selected-count": "Selected: ",
+        "revealed-count": "Revealed: ",
+        "mods-count": "Mods: "
+      }
+    }
+  },
+  "months": {
+    "january": "January",
+    "february": "February",
+    "march": "March",
+    "april": "April",
+    "may": "May",
+    "june": "June",
+    "july": "July",
+    "august": "August",
+    "september": "September",
+    "october": "October",
+    "november": "November",
+    "december": "December"
+  },
+  "jam": {
+    "common": {
+      "results": "Results",
+      "podium": {
+        "first": "🥇 First place",
+        "second": "🥈 Second place",
+        "third": "🥉 Third place",
+        "withcolumn": {
+          "first": "🥇 First place:",
+          "second": "🥈 Second place:",
+          "third": "🥉 Third place:"
+        }
+      },
+      "start-finish": {
+        "start": "🟢 Jam start:",
+        "end": "🔴 Jam end:"
+      },
+      "time-zone": "Time zone:",
+      "credits": "Credits",
+      "submissions": "Submissions",
+      "original-jam": "The following sections contain all the information originally included in this jam page, while the jam was still running."
+    },
+    "janv2023": {
+      "title": "Outer Wilds New Horizons Jam",
+      "title-short": "New Horizons Jam",
+      "description": "Create an addon for New Horizons and win cash prizes!",
+      "intro": {
+        "1": "The jam is over!",
+        "2": "After playing through them all, the judges voted on the submissions, and in the end some of the results were tied. We decided to make a last minute change. Instead of offering three different prizes for first, second, and third places, we increased the prize pool and are instead having four winners: two submissions in first place, and two in second!"
+      },
+      "prizes": {
+        "first": "($100 to each team)",
+        "second": "($75 to each team)"
+      }
+    },
+    "newhorizons-jam": {
+      "intro": {
+        "1": "Welcome to the",
+        "2": "! In this jam, you'll have one week to create custom content for",
+        "3": ", following a theme that will be revealed once the jam starts.",
+        "4": "To add custom content to Outer Wilds, you will use",
+        "5": "You can decide what kind of content you wanna create. You can stick to the original Outer Wilds solar system and just modify some existing planets, or add a few new ones. Or maybe you'll create a completely new system with new planets. Or you can go even further by using custom models, textures, sounds, dialogue, etc. Or anything in between! The",
+        "6": "explain what's possible to create using this mod.",
+        "7": "No programming knowledge is required!",
+        "title": "New Horizons Jam"
+      },
+      "theme": {
+        "1": "The themes are",
+        "2": "and",
+        "3": "You decide how to interpret the themes. You can chose to follow one of the themes, or both. You won't be penalized for only following one theme. Make sure you read the",
+        "4": "rules",
+        "5": "and the",
+        "6": "judging criteria",
+        "title": "Theme",
+        "themes": {
+          "1": "CLOCKWORK",
+          "2": "LAYERS"
+        }
+      },
+      "prizes": {
+        "1": "Amounts in USD. All winners will also get a special role on",
+        "2": "our Discord server",
+        "3": ". There will also be some extra Steam keys for winners or other participants, still to be decided.",
+        "4": "Note: cash prizes will be given via PayPal only. No other methods will be supported.",
+        "prizes": {
+          "first": "$100",
+          "second": "$75",
+          "third": "$50"
+        },
+        "title": "Prizes"
+      },
+      "rules": {
+        "1": "Submissions must be an open source addon for",
+        "2": ".",
+        "3": "No custom code",
+        "4": ". Submissions must use the basic New Horizons config dll. That means you're limited to using the New Horizons JSON configs, XML text assets, and asset bundles created in Unity, which can include custom textures, models, sounds, etc. Basically everything New Horizons supports, except custom code.",
+        "5": "No extra dependencies",
+        "6": ". The mod you submit must only have one dependency: New Horizons. It can not depend on any other mods.",
+        "7": "There must be at least one release uploaded to GitHub within the jam deadline.",
+        "8": "You can make as many releases as you want, but releases made outside the deadline won't be considered.",
+        "9": "Do not to overwrite releases, as this will change the upload date of that release.",
+        "10": "You can only contribute to one submission.",
+        "11": "You can't submit multiple mods, or submit one mod solo and one in a team, or participate in multiple teams.",
+        "12": "All submissions must follow the",
+        "13": "Mobius Digital Fan Content Policy",
+        "14": ".",
+        "15": "You can use any assets you have a license to use.",
+        "16": "Besides using assets already available in the game, you're allowed to use assets you find (models, textures, sounds, etc), but you must be careful to understand and follow their licenses, just like you would in any open source project. And of course, these assets must also follow the digital content policy mentioned above.",
+        "title": "Rules"
+      },
+      "criteria": {
+        "1": "After the jam deadline has ended, we will play each submission and review them based on the following criteria:",
+        "2": "How well does it follow the themes?",
+        "3": "There are two themes. You can chose to follow one of the themes, or both. You won't be penalized for only following one theme. A submission that only follows one theme really well can be as good as a submission that follows both themes kinda well.",
+        "4": "How polished is it?",
+        "5": "We will value quality over quantity. One highly polished planet is better than 20 empty planets.",
+        "6": "How well does it leverage New Horizons?",
+        "7": "The point of the jam is to take NH to its limits, so we will prefer submissions that take full advantage of what NH has to offer and use it in creative ways. But again, quality over quantity: it's better to use a few features really well, than trying to cramp all the features in there with no need for them.",
+        "8": "How well are the assets used?",
+        "9": "Whether you add your own custom assets (models, textures, sounds, etc), or reuse the ones included in the game, they should fit the world they are used in. We'll take into account the overall quality of the visuals/audio and how it all fits together. So a highly detailed custom model with high resolution textures doesn't really mean anything if everything around it doesn't follow the same standards.",
+        "10": "Overall opinion.",
+        "11": "The judges are (allegedly) people, so the review process will be mostly driven by personal opinion. The judging criteria are guidelines we'll use while reviewing the submissions, they're not strict rules or values to be fed into a formula.",
+        "12": "These guidelines can change depending on how the jam is going. We might also take a shot at community voting, if there are enough submissions to justify it and we can set up a good system for it.",
+        "title": "Judging Criteria"
+      },
+      "participate": {
+        "1": "TL;DR",
+        "2": ": Upload a New Horizons addon with",
+        "3": "no custom code",
+        "4": "during the jam period, and give it the",
+        "5": "jam",
+        "6": "tag when submitting to the mod database.",
+        "7": "To participate, you will need to submit a New Horizons addon to the Outer Wilds mod database.",
+        "8": "Read the New Horizon docs to learn how to make your addon.",
+        "9": "Your addon can not use custom code",
+        "10": "That means the only dll file in your mod should be the",
+        "11": "file that's included in the",
+        "12": "New Horizons Addon Template",
+        "13": ". You can, however, use",
+        "14": "asset bundles",
+        "15": "to add custom content to your addon (models, textures, sounds, etc).",
+        "16": "Use these tools to create your content",
+        "17": "The",
+        "18": "explain in detail how to edit the required JSON files with editors like Visual Studio Code. But you can also use the",
+        "19": "New Horizons Config Editor App",
+        "20": ", which gives you a more friendly interface for creating, editing, and managing all of the addon files.",
+        "21": "Upload a release within the deadline",
+        "22": "If you're using the",
+        "23": "to create your addon (which you should), it will automatically create new addon releases when you bump the version in your",
+        "24": "file, as described in the",
+        "25": "You must upload a release of your addon within the jam deadline. It's OK if you submit the mod to the database after the deadline is over, as long as a valid release was uploaded within the deadline.",
+        "26": "Be careful not to overwrite releases",
+        "27": ", as this would change the upload date. Always upload new releases separately. If you're using the New Horizons template and letting it take care of creating releases for you, then you shouldn't need to worry about this.",
+        "28": "If you upload new releases to your jam mod after the deadline has passed, those releases will be ignored. The most recent release that was uploaded within the deadline will be your submission.",
+        "29": "Use the",
+        "30": "tag when submitting to the mod database",
+        "31": "When you submit your addon to the database, you will need to include the",
+        "32": "tag, together with any other tags that make sense for your addon. Every New Horizons addon typically also has the",
+        "33": "tag, since they add custom content to the game.",
+        "title": "How to participate"
+      },
+      "teams": {
+        "1": "You are allowed to form teams as you wish. But we'd prefer for teams to be on the smaller size (2-3 people), because otherwise we might not have enough submissions to make the jam interesting.",
+        "2": "Prize rewards will be split equally among all team members, no exceptions. That means you will get half the prize if you're on a two person team.",
+        "3": "If you're looking for a team,",
+        "4": "join our Discord",
+        "5": "and ask around there.",
+        "title": "Teams"
+      },
+      "talk": {
+        "1": "Join our Discord server if you have more questions, or just wanna discuss anything related to the jam, modding, etc. We have a",
+        "2": "channel specifically for this. Also make sure to go to the",
+        "3": "channel and get the Jam role, so you can be notified of jam updates.",
+        "title": "Talk to us"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"@sveltejs/adapter-auto": "^2.0.0",
 		"@sveltejs/adapter-static": "^2.0.1",
 		"@sveltejs/kit": "^1.11.0",
+		"@types/gtag.js": "^0.0.12",
 		"@types/lodash-es": "^4.17.6",
 		"@types/sharp": "^0.31.1",
 		"@typescript-eslint/eslint-plugin": "^5.54.1",
@@ -28,8 +29,7 @@
 		"tailwindcss": "^3.2.7",
 		"tslib": "^2.5.0",
 		"typescript": "^4.9.5",
-		"vite": "^4.1.4",
-		"@types/gtag.js": "^0.0.12"
+		"vite": "^4.1.4"
 	},
 	"scripts": {
 		"dev": "vite dev --host",
@@ -40,5 +40,8 @@
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",
 		"format": "prettier --plugin-search-dir . --write .",
 		"post:build": "node post-build.mjs"
+	},
+	"dependencies": {
+		"svelte-i18n": "^3.6.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,13 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
+
+dependencies:
+  svelte-i18n:
+    specifier: ^3.6.0
+    version: 3.6.0(svelte@3.56.0)
 
 devDependencies:
   '@sveltejs/adapter-auto':
@@ -320,6 +325,40 @@ packages:
     resolution: {integrity: sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
+
+  /@formatjs/ecma402-abstract@1.11.4:
+    resolution: {integrity: sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==}
+    dependencies:
+      '@formatjs/intl-localematcher': 0.2.25
+      tslib: 2.5.0
+    dev: false
+
+  /@formatjs/fast-memoize@1.2.1:
+    resolution: {integrity: sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==}
+    dependencies:
+      tslib: 2.5.0
+    dev: false
+
+  /@formatjs/icu-messageformat-parser@2.1.0:
+    resolution: {integrity: sha512-Qxv/lmCN6hKpBSss2uQ8IROVnta2r9jd3ymUEIjm2UyIkUCHVcbUVRGL/KS/wv7876edvsPe+hjHVJ4z8YuVaw==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.11.4
+      '@formatjs/icu-skeleton-parser': 1.3.6
+      tslib: 2.5.0
+    dev: false
+
+  /@formatjs/icu-skeleton-parser@1.3.6:
+    resolution: {integrity: sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.11.4
+      tslib: 2.5.0
+    dev: false
+
+  /@formatjs/intl-localematcher@0.2.25:
+    resolution: {integrity: sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==}
+    dependencies:
+      tslib: 2.5.0
+    dev: false
 
   /@humanwhocodes/config-array@0.11.8:
     resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
@@ -823,6 +862,17 @@ packages:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
     dev: true
 
+  /cli-color@2.0.3:
+    resolution: {integrity: sha512-OkoZnxyC4ERN3zLzZaY9Emb7f/MhBOIpePv0Ycok0fJYT+Ouo00UBEIwsVsr0yoow++n5YWlSUgST9GKhNHiRQ==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      d: 1.0.1
+      es5-ext: 0.10.62
+      es6-iterator: 2.0.3
+      memoizee: 0.4.15
+      timers-ext: 0.1.7
+    dev: false
+
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -883,6 +933,13 @@ packages:
     hasBin: true
     dev: true
 
+  /d@1.0.1:
+    resolution: {integrity: sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==}
+    dependencies:
+      es5-ext: 0.10.62
+      type: 1.2.0
+    dev: false
+
   /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -914,7 +971,6 @@ packages:
   /deepmerge@4.3.0:
     resolution: {integrity: sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /defined@1.0.1:
     resolution: {integrity: sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==}
@@ -980,9 +1036,43 @@ packages:
     resolution: {integrity: sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==}
     dev: true
 
+  /es5-ext@0.10.62:
+    resolution: {integrity: sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==}
+    engines: {node: '>=0.10'}
+    requiresBuild: true
+    dependencies:
+      es6-iterator: 2.0.3
+      es6-symbol: 3.1.3
+      next-tick: 1.1.0
+    dev: false
+
+  /es6-iterator@2.0.3:
+    resolution: {integrity: sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==}
+    dependencies:
+      d: 1.0.1
+      es5-ext: 0.10.62
+      es6-symbol: 3.1.3
+    dev: false
+
   /es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
     dev: true
+
+  /es6-symbol@3.1.3:
+    resolution: {integrity: sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==}
+    dependencies:
+      d: 1.0.1
+      ext: 1.7.0
+    dev: false
+
+  /es6-weak-map@2.0.3:
+    resolution: {integrity: sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==}
+    dependencies:
+      d: 1.0.1
+      es5-ext: 0.10.62
+      es6-iterator: 2.0.3
+      es6-symbol: 3.1.3
+    dev: false
 
   /esbuild@0.16.17:
     resolution: {integrity: sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==}
@@ -1165,15 +1255,32 @@ packages:
     engines: {node: '>=4.0'}
     dev: true
 
+  /estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: false
+
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /event-emitter@0.3.5:
+    resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
+    dependencies:
+      d: 1.0.1
+      es5-ext: 0.10.62
+    dev: false
+
   /expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
     dev: true
+
+  /ext@1.7.0:
+    resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
+    dependencies:
+      type: 2.7.2
+    dev: false
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1300,7 +1407,6 @@ packages:
 
   /globalyzer@0.1.0:
     resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
-    dev: true
 
   /globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -1327,7 +1433,6 @@ packages:
 
   /globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-    dev: true
 
   /graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
@@ -1394,6 +1499,15 @@ packages:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
     dev: true
 
+  /intl-messageformat@9.13.0:
+    resolution: {integrity: sha512-7sGC7QnSQGa5LZP7bXLDhVDtQOeKGeBFGHF2Y8LVBwYZoQZCgWeKoPGTa5GMG8g/TzDgeXuYJQis7Ggiw2xTOw==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.11.4
+      '@formatjs/fast-memoize': 1.2.1
+      '@formatjs/icu-messageformat-parser': 2.1.0
+      tslib: 2.5.0
+    dev: false
+
   /is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
     dev: true
@@ -1432,6 +1546,10 @@ packages:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
     dev: true
+
+  /is-promise@2.2.2:
+    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
+    dev: false
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1496,6 +1614,12 @@ packages:
       yallist: 4.0.0
     dev: true
 
+  /lru-queue@0.1.0:
+    resolution: {integrity: sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==}
+    dependencies:
+      es5-ext: 0.10.62
+    dev: false
+
   /magic-string@0.27.0:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
     engines: {node: '>=12'}
@@ -1526,6 +1650,19 @@ packages:
   /mdurl@1.0.1:
     resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
     dev: true
+
+  /memoizee@0.4.15:
+    resolution: {integrity: sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==}
+    dependencies:
+      d: 1.0.1
+      es5-ext: 0.10.62
+      es6-weak-map: 2.0.3
+      event-emitter: 0.3.5
+      is-promise: 2.2.2
+      lru-queue: 0.1.0
+      next-tick: 1.1.0
+      timers-ext: 0.1.7
+    dev: false
 
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1580,7 +1717,6 @@ packages:
   /mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
-    dev: true
 
   /mrmime@1.0.1:
     resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
@@ -1608,6 +1744,10 @@ packages:
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
+
+  /next-tick@1.1.0:
+    resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
+    dev: false
 
   /node-abi@3.33.0:
     resolution: {integrity: sha512-7GGVawqyHF4pfd0YFybhv/eM9JwTtPqx0mAanQ146O3FlSh3pA24zf9IRQTOsfTSqXTNzPSP5iagAJ94jjuVog==}
@@ -1936,7 +2076,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       mri: 1.2.0
-    dev: true
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -2139,6 +2278,22 @@ packages:
       svelte: 3.56.0
     dev: true
 
+  /svelte-i18n@3.6.0(svelte@3.56.0):
+    resolution: {integrity: sha512-qvvcMqHVCXJ5pHoQR5uGzWAW5vS3qB9mBq+W6veLZ6jkrzZGOziR+wyOUJsc59BupMh+Ae30qjOndFrRU6v5jA==}
+    engines: {node: '>= 16'}
+    hasBin: true
+    peerDependencies:
+      svelte: ^3.25.1
+    dependencies:
+      cli-color: 2.0.3
+      deepmerge: 4.3.0
+      estree-walker: 2.0.2
+      intl-messageformat: 9.13.0
+      sade: 1.8.1
+      svelte: 3.56.0
+      tiny-glob: 0.2.9
+    dev: false
+
   /svelte-markdown@0.2.3(svelte@3.56.0):
     resolution: {integrity: sha512-2h680NzTXnAD0CXhxe3GeHl6W+ayG4iKQRl+BIDRw+R0mUE0OiNxP1Vt8Rn+aWevB/LBiBIPCAwvL+0BkG057A==}
     peerDependencies:
@@ -2201,7 +2356,6 @@ packages:
   /svelte@3.56.0:
     resolution: {integrity: sha512-LvXiJbjdvJKwB/0CQyYpDX0q+hFqCyWmybzC2G6eK1tJJA/RSRCytTfNmjHv+RHlLuA70vWG7nXp6gbeErYvRA==}
     engines: {node: '>= 8'}
-    dev: true
 
   /tailwindcss@3.2.7(postcss@8.4.21):
     resolution: {integrity: sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==}
@@ -2261,12 +2415,18 @@ packages:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
 
+  /timers-ext@0.1.7:
+    resolution: {integrity: sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==}
+    dependencies:
+      es5-ext: 0.10.62
+      next-tick: 1.1.0
+    dev: false
+
   /tiny-glob@0.2.9:
     resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
     dependencies:
       globalyzer: 0.1.0
       globrex: 0.1.2
-    dev: true
 
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2286,7 +2446,6 @@ packages:
 
   /tslib@2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
-    dev: true
 
   /tsutils@3.21.0(typescript@4.9.5):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -2315,6 +2474,14 @@ packages:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
     dev: true
+
+  /type@1.2.0:
+    resolution: {integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==}
+    dev: false
+
+  /type@2.7.2:
+    resolution: {integrity: sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==}
+    dev: false
 
   /typescript@4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,11 @@
+// For docs see https://github.com/kaisermann/svelte-i18n/blob/main/docs/Getting%20Started.md
+import { getLocaleFromNavigator, init, addMessages as registerLocale } from 'svelte-i18n';
+
+import en from '../locales/en.json';
+
+registerLocale('en', en);
+
+init({
+  fallbackLocale: 'en',
+  initialLocale: getLocaleFromNavigator(),
+});

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,5 +1,6 @@
 <script lang="ts" context="module">
 	import { page } from '$app/stores';
+	import { _ } from 'svelte-i18n';
 </script>
 
 <script lang="ts">
@@ -7,10 +8,7 @@
 	import ErrorMessage from '$lib/components/error-message.svelte';
 </script>
 
-<PageContainer
-	title="Error - Outer Wilds Mods"
-	description="Something went wrong on the Outer Wilds Mods website"
->
+<PageContainer title={$_('error.title')} description={$_('error.description')}>
 	<ErrorMessage />
 	<code class="whitespace-pre-wrap break-words">{$page.status}: {$page.error?.message}</code>
 </PageContainer>

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -3,6 +3,8 @@ import { getModTags } from '$lib/helpers/get-mod-tags';
 import { error } from '@sveltejs/kit';
 import type { ModsRequestItem } from './api/mods.json/+server';
 
+import '../i18n'; // localization
+
 export const load: LayoutLoad = async ({ fetch }) => {
 	const modsResult = await fetch('/api/mods.json');
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,6 +8,7 @@
 	import type { PageData } from './$types';
 	import DiscordLink from '$lib/components/discord-link.svelte';
 	import ModCard from '$lib/components/mod-grid/mod-card.svelte';
+	import { _ } from 'svelte-i18n';
 
 	const modsPerCategory = 3;
 
@@ -37,70 +38,74 @@
 </svelte:head>
 
 <PageContainer
-	title="Outer Wilds Mods - Download and Install Mods for Outer Wilds"
-	description="Find all the tools needed to mod Outer Wilds. Download and install mods with the Outer Wilds Mod Manager."
+	title={$_('main.header.title')}
+	description={$_('main.header.description')}
 	imageUrl="{websiteUrl}/images/opengraph.webp"
 	imageWidth={1200}
 	imageHeight={600}
 >
 	<PageSection isNarrow id="outer-wilds-mods">
-		<h1 class="text-base inline">Outer Wilds Mods</h1>
+		<h1 class="text-base inline">{$_('general.websitename')}</h1>
 		<p class="m-0 inline">
-			are unofficial modifications for <a
-				class="link"
-				href="https://www.mobiusdigitalgames.com/outer-wilds.html">Outer Wilds</a
-			>, which add new features, improvements, extra content, and more. Use the
-			<a class="link" href="/mod-manager">Mod Manager</a> to easily download and install these mods.
-			There are currently a total of {modList.length} mods, addons, and utilities.
+			{$_('main.body.hero.1')}
+			<a class="link" href="https://www.mobiusdigitalgames.com/outer-wilds.html"
+				>{$_('general.outerwilds')}</a
+			>{$_('main.body.hero.2')}
+			<a class="link" href="/mod-manager">{$_('general.modmanager')}</a>
+			{$_('main.body.hero.3')}
 		</p>
 	</PageSection>
-	<PageSection id="mods" title="Some of our mods">
+	<PageSection id="mods" title={$_('main.body.mods.title')}>
 		<div class="flex gap-8 text-center md:flex-row flex-col">
-			<FeaturedModSection title="Hot Mods" sortOrder="hot" mods={hotMods} />
-			<FeaturedModSection title="New Mods" sortOrder="newest" mods={newMods} />
-			<FeaturedModSection title="Recently Updated" sortOrder="updated" mods={updatedMods} />
+			<FeaturedModSection title={$_('main.body.mods.cols.hot')} sortOrder="hot" mods={hotMods} />
+			<FeaturedModSection title={$_('main.body.mods.cols.new')} sortOrder="newest" mods={newMods} />
+			<FeaturedModSection
+				title={$_('main.body.mods.cols.update')}
+				sortOrder="updated"
+				mods={updatedMods}
+			/>
 		</div>
 	</PageSection>
 	<PageSection
-		title="Support and modding talk"
+		title={$_('main.body.support.title')}
 		id="community"
-		description="Join our Discord server if you need support, wanna learn about making mods, or just to chat with this wonderful modding community:"
+		description={$_('main.body.support.description')}
 		isNarrow
 	>
 		<DiscordLink />
 	</PageSection>
 	<PageSection
-		title="Become a modder"
+		title={$_('main.body.become.title')}
 		id="become-a-modder"
-		description="If you want to make your own mods, the OWML documentation has most of the info you need to get started. The easiest way to start is by cloning the mod template project and following the instructions there. Also, that Discord server linked above is full of people who will help you."
+		description={$_('main.body.become.description')}
 		isNarrow
 	>
 		<LinkList
 			links={[
 				{
-					text: 'Read the OWML docs to learn how to make mods',
+					text: $_('main.body.become.links.owml'),
 					href: 'https://owml.outerwildsmods.com',
 				},
 				{
-					text: 'Outer Wilds mod template',
+					text: $_('main.body.become.links.template'),
 					href: 'https://github.com/ow-mods/ow-mod-template',
 				},
 			]}
 		/>
 	</PageSection>
 	{#if newHorizons}
-		<PageSection title="Create custom content with New Horizons" id="become-a-modder" isNarrow>
+		<PageSection title={$_('main.body.newhorizons.title')} id="become-a-modder" isNarrow>
 			<ModCard mod={newHorizons} />
 			<p>
-				With <a class="link" href="/mods/newhorizons">New Horizons</a>, you can create new planets
-				and edit existing ones. Create new stories with character dialogue, translatable text, ship
-				log entries, etc. You can make custom content without any coding knowledge, but you can also
-				add your own code to further improve your creations.
+				{$_('main.body.newhorizons.description.1')}
+				<a class="link" href="/mods/newhorizons">{$_('general.newhorizons')}</a>{$_(
+					'main.body.newhorizons.description.2'
+				)}
 			</p>
 			<LinkList
 				links={[
 					{
-						text: 'Read the New Horizons docs',
+						text: $_('main.body.newhorizons.links.docs'),
 						href: 'https://nh.outerwildsmods.com/',
 					},
 				]}
@@ -108,24 +113,24 @@
 		</PageSection>
 	{/if}
 	<PageSection
-		title="Outer Wilds?"
+		title="{$_('general.outerwilds')}{$_('main.body.outerwilds.title-questionmark')}"
 		id="outer-wilds"
-		description="Outer Wilds is a neat game. Check it out and buy it or whatever."
+		description={$_('main.body.outerwilds.description')}
 		imageUrl="/images/outer-wilds.webp"
 		isNarrow
 	>
 		<LinkList
 			links={[
 				{
-					text: 'Steam',
+					text: $_('general.steam'),
 					href: 'https://store.steampowered.com/app/753640/Outer_Wilds',
 				},
 				{
-					text: 'Epic',
+					text: $_('general.epicgames'),
 					href: 'https://www.epicgames.com/store/en-US/product/outerwilds',
 				},
 				{
-					text: 'Official website',
+					text: $_('main.body.outerwilds.links.website'),
 					href: 'https://www.mobiusdigitalgames.com/outer-wilds.html',
 				},
 			]}

--- a/src/routes/404/+page.svelte
+++ b/src/routes/404/+page.svelte
@@ -1,11 +1,9 @@
 <script>
 	import ErrorMessage from '$lib/components/error-message.svelte';
 	import PageContainer from '$lib/components/page-container.svelte';
+	import { _ } from 'svelte-i18n';
 </script>
 
-<PageContainer
-	title="Not Found - Outer Wilds Mods"
-	description="Something went wrong on the Outer Wilds Mods website"
->
+<PageContainer title={$_('404.title')} description={$_('404.description')}>
 	<ErrorMessage />
 </PageContainer>

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -2,6 +2,7 @@
 	import { getModDatabase, type Mod } from '$lib/helpers/api/get-mod-database';
 	import { sortBy } from 'lodash-es';
 	import { onMount } from 'svelte';
+	import { _ } from 'svelte-i18n';
 
 	type Event = {
 		date: Date;
@@ -11,121 +12,129 @@
 	const events: Event[] = [
 		{
 			date: new Date(0),
-			title: 'The Big Bang',
+			title: $_('history.timeline.bigbang'),
 		},
 		{
 			date: new Date('2011/6/15'),
-			title: 'Spaceworthy',
+			title: $_('history.timeline.spaceworthy'),
 		},
 		{
 			date: new Date('2012/12/10'),
-			title: 'Outer Wilds Alpha',
+			title: $_('history.timeline.alpha'),
 		},
 		{
 			date: new Date('2019/05/28'),
-			title: 'Outer Wilds released',
+			title: $_('history.timeline.release'),
 		},
 		{
 			date: new Date('2019/06/08'),
-			title: 'TAImatem joins',
+			title: $_('history.timeline.taimatem'),
 		},
 		{
 			date: new Date('2019/12/08'),
-			title: 'Alek joins',
+			title: $_('history.timeline.alek'),
 		},
 		{
 			date: new Date('2019/12/18'),
-			title: 'First OWML release',
+			title: $_('history.timeline.owml'),
 		},
 		{
 			date: new Date('2019/12/28'),
-			title: '_nebula joins',
+			title: $_('history.timeline._nebula'),
 		},
 		{
 			date: new Date('2020/01/03'),
-			title: 'Nexus Mods page created',
+			title: $_('history.timeline.nexusmods'),
 		},
 		{
 			date: new Date('2020/01/04'),
-			title: 'Raicuparta joins',
+			title: $_('history.timeline.raicuparta'),
 		},
 		{
 			date: new Date('2020/01/06'),
-			title: 'First NomaiVR release',
+			title: $_('history.timeline.nomaivr'),
 		},
 		{
 			date: new Date('2020/02/01'),
-			title: 'Logan emails',
+			title: $_('history.timeline.logan-email'),
 		},
 		{
 			date: new Date('2020/03/01'),
-			title: 'First QSB release',
+			title: $_('history.timeline.qsb'),
 		},
 		{
 			date: new Date('2020/03/15'),
-			title: 'Modders join OWML team',
+			title: $_('history.timeline.modders-join'),
 		},
 		{
 			date: new Date('2020/04/10'),
-			title: 'Marshmallow',
+			title: $_('history.timeline.marshmallow'),
 		},
 		{
 			date: new Date('2020/04/20'),
-			title: 'Mod manager',
+			title: $_('history.timeline.modmanager'),
 		},
 		{
 			date: new Date('2020/05/15'),
-			title: 'Mod database',
+			title: $_('history.timeline.moddatabase'),
 		},
 		{
 			date: new Date('2020/06/15'),
-			title: 'Mods website',
+			title: $_('history.timeline.modswebsite'),
 		},
 		{
 			date: new Date('2020/08/15'),
-			title: 'Alpha modding',
+			title: $_('history.timeline.alpha-modding'),
 		},
 		{
 			date: new Date('2021/04/15'),
-			title: 'DLC leak',
+			title: $_('history.timeline.eotw-leak'),
 		},
 		{
 			date: new Date('2021/06/15'),
-			title: 'DLC announced',
+			title: $_('history.timeline.eotw-announce'),
 		},
 		{
 			date: new Date('2021/08/15'),
-			title: 'JohnCorby',
+			title: $_('history.timeline.johncorby'),
 		},
 		{
 			date: new Date('2021/09/5'),
-			title: 'Logan joins Discord',
+			title: $_('history.timeline.logan-discord'),
 		},
 		{
 			date: new Date('2021/09/25'),
-			title: 'DLC releases',
+			title: $_('history.timeline.eotw-release'),
 		},
 		{
 			date: new Date('2021/11/15'),
-			title: 'Xen',
+			title: $_('history.timeline.xen'),
 		},
 		{
 			date: new Date('2021/12/15'),
-			title: 'New Horizons',
+			title: $_('history.timeline.newhorizons'),
 		},
 		{
 			date: new Date('2022/01/15'),
-			title: 'Modding Discord server',
+			title: $_('history.timeline.discord'),
 		},
 		{
 			date: new Date(),
-			title: 'Present',
+			title: $_('history.timeline.present'),
 		},
 		{
 			date: new Date(Math.pow(2, 31) * 1000),
-			title: 'Heat death of the Universe',
+			title: $_('history.timeline.universe-death'),
 		},
 	];
+
+	// EcmaScript doesn't have a way to get the month name in the current language, hence this madness.
+	const getLocatedMonth = (date: Date) => {
+		const engMonth = date.toLocaleString('default', { month: 'long' });
+
+		return $_('months.' + engMonth.toLowerCase());
+		// this is better than a switch case, right?
+	};
 
 	const firstEvent = events[0];
 	const lastEvent = events[events.length - 1];
@@ -267,11 +276,15 @@
 
 <div style="--transition-time: {transitionTimeMs}ms;">
 	<div class="flex gap-2 mb-20 fixed flex-col z-30">
-		<button on:click={selectPreviousEvent} class="link button bg-darker">Previous</button>
-		<button on:click={selectNextEvent} class="link button bg-darker">Next</button>
-		<span>Transitions: {transitionTimeMs}ms</span>
+		<button on:click={selectPreviousEvent} class="link button bg-darker"
+			>{$_('history.timeline.controls.previous')}</button
+		>
+		<button on:click={selectNextEvent} class="link button bg-darker"
+			>{$_('history.timeline.controls.next')}</button
+		>
+		<span>{$_('history.timeline.controls.transitions-time')}{transitionTimeMs}ms</span>
 		<input type="range" min={100} max={3000} bind:value={transitionTimeMs} />
-		<span>Scale: {scale}</span>
+		<span>{$_('history.timeline.controls.scale')}{scale}</span>
 		<input
 			type="range"
 			min={0.1}
@@ -280,9 +293,9 @@
 			step={0.05}
 			on:change={() => scrollTo(selectedEventImmediate)}
 		/>
-		<span>Selected: {selectedEvent}</span>
-		<span>Revealed: {revealedEvent}</span>
-		<span>Mods: {mods.length}</span>
+		<span>{$_('history.timeline.controls.selected-count')}{selectedEvent}</span>
+		<span>{$_('history.timeline.controls.revealed-count')}{revealedEvent}</span>
+		<span>{$_('history.timeline.controls.mods-count')}{mods.length}</span>
 	</div>
 	<div bind:this={scrollWrapper} class="overflow-auto relative wrapper">
 		<div
@@ -318,7 +331,8 @@
 					>
 						<div class="relative h-full">
 							<span class="sticky top-1/2 m-4 inline-block font-semibold h-0 leading-0">
-								{month.toLocaleString('default', { month: 'long' })}
+								{getLocatedMonth(month)}
+								<!-- See the function at the top of the script -->
 							</span>
 						</div>
 					</div>

--- a/src/routes/jam/jan-2023/+page.svelte
+++ b/src/routes/jam/jan-2023/+page.svelte
@@ -8,6 +8,7 @@
 	import type { PageData } from './$types';
 	import JamCredits from '../jam-credits.svelte';
 	import JamWinnerBlock from '../jam-winner-block.svelte';
+	import { _ } from 'svelte-i18n';
 
 	export let data: PageData;
 	const { modList } = data;
@@ -50,264 +51,262 @@
 </script>
 
 <PageContainer
-	title="Outer Wilds New Horizons Jam"
-	description="Create an addon for New Horizons and win cash prizes!"
+	title={$_('jam.janv2023.title')}
+	description={$_('jam.janv2023.description')}
 	imageUrl="{websiteUrl}/images/jam.webp"
 	imageWidth={665}
 	imageHeight={416}
 >
-	<PageSection title="New Horizons Jam" id="nh-jam" isNarrow>
+	<PageSection title={$_('jam.janv2023.title-short')} id="nh-jam" isNarrow>
 		<p>
-			<strong>The jam is over!</strong> After playing through them all, the judges voted on the submissions,
-			and in the end some of the results were tied. We decided to make a last minute change. Instead
-			of offering three different prizes for first, second, and third places, we increased the prize
-			pool and are instead having four winners: two submissions in first place, and two in second!
+			<strong>{$_('jam.janv2023.intro.1')}</strong>
+			{$_('jam.janv2023.intro.2')}
 		</p>
 	</PageSection>
-	<PageSection title="Results" id="results" isNarrow>
-		<JamWinnerBlock title="🥇 First place" subtitle="($100 to each team)" mods={firstPlaceMods} />
-		<JamWinnerBlock title="🥈 Second place" subtitle="($75 to each team)" mods={secondPlaceMods} />
+	<PageSection title={$_('jam.common.results')} id="results" isNarrow>
+		<JamWinnerBlock
+			title={$_('jam.common.podium.first')}
+			subtitle={$_('jam.janv2023.prizes.first')}
+			mods={firstPlaceMods}
+		/>
+		<JamWinnerBlock
+			title={$_('jam.common.podium.second')}
+			subtitle={$_('jam.janv2023.prizes.second')}
+			mods={secondPlaceMods}
+		/>
 	</PageSection>
-	<PageSection title="Credits" id="credits" isNarrow>
+	<PageSection title={$_('jam.common.credits')} id="credits" isNarrow>
 		<JamCredits />
 	</PageSection>
-	<PageSection title="Submissions" id="submissions">
+	<PageSection title={$_('jam.common.submissions')} id="submissions">
 		<ModGrid mods={jamMods} allowFiltering={false} defaultSortOrder="leastDownloaded" />
 	</PageSection>
 	<PageSection title="Original Jam Page" id="nh-jam-original" isNarrow>
 		<p>
-			The following sections contain all the information originally included in this jam page, while
-			the jam was still running.
+			{$_('jam.common.original-jam')}
 		</p>
 		<img src="/images/jam.webp" alt="New Horizons Jam" />
 		<p>
-			Welcome to the <strong>New Horizons Jam</strong>! In this jam, you'll have one week to create
-			custom content for
+			{$_('jam.newhorizons-jam.intro.1')}
+			<strong>{$_('jam.newhorizons-jam.intro.title')}</strong>{$_('jam.newhorizons-jam.intro.2')}
 			<a class="link" href="https://store.steampowered.com/app/753640/Outer_Wilds/">
-				Outer Wilds
-			</a>, following a theme that will be revealed once the jam starts.
+				{$_('general.outerwilds')}
+			</a>{$_('jam.newhorizons-jam.intro.3')}
 		</p>
 		<p>
-			To add custom content to Outer Wilds, you will use <a class="link" href="/mods/newhorizons"
-				>New Horizons</a
-			>. You can decide what kind of content you wanna create. You can stick to the original Outer
-			Wilds solar system and just modify some existing planets, or add a few new ones. Or maybe
-			you'll create a completely new system with new planets. Or you can go even further by using
-			custom models, textures, sounds, dialogue, etc. Or anything in between! The
-			<a class="link" href="https://nh.outerwildsmods.com"> New Horizons Docs</a> explain what's possible
-			to create using this mod.
+			{$_('jam.newhorizons-jam.intro.4')}
+			<a class="link" href="/mods/newhorizons">{$_('general.newhorizons')}</a>{$_(
+				'jam.newhorizons-jam.intro.5'
+			)}.
+			<a class="link" href="https://nh.outerwildsmods.com"> {$_('general.newhorizons-docs')}</a>
+			{$_('jam.newhorizons-jam.intro.6')}
 		</p>
-		<p><strong>No programming knowledge is required!</strong></p>
+		<p><strong>{$_('jam.newhorizons-jam.intro.7')}</strong></p>
 	</PageSection>
-	<PageSection title="Theme" id="theme" isNarrow>
+	<PageSection title={$_('jam.newhorizons-jam.theme.title')} id="theme" isNarrow>
 		<p class="text-xl">
-			The themes are <strong>CLOCKWORK</strong> and <strong>LAYERS</strong>
+			{$_('jam.newhorizons-jam.theme.1')}
+			<strong>{$_('jam.newhorizons-jam.theme.themes.1')}</strong>
+			{$_('jam.newhorizons-jam.theme.2')}
+			<strong>{$_('jam.newhorizons-jam.theme.themes.2')}</strong>
 		</p>
 		<p>
-			You decide how to interpret the themes. You can chose to follow one of the themes, or both.
-			You won't be penalized for only following one theme. Make sure you read the <a
-				href="#rules"
-				class="link">rules</a
-			>
-			and the <a href="#criteria" class="link">judging criteria</a>.
+			{$_('jam.newhorizons-jam.theme.3')}
+			<a href="#rules" class="link">{$_('jam.newhorizons-jam.theme.4')}</a>
+			{$_('jam.newhorizons-jam.theme.5')}
+			<a href="#criteria" class="link">{$_('jam.newhorizons-jam.theme.6')}</a>.
 		</p>
 	</PageSection>
 	<PageSection title="Duration" id="duration" isNarrow>
 		<div class="text-xl flex flex-col m-auto w-fit gap-4">
-			<span>🟢 Jam start: <strong>{startDateText}</strong></span>
-			<span>🔴 Jam end: <strong>{endDateText}</strong></span>
-			<small>(Time zone: {timeZoneText})</small>
+			<span>{$_('jam.common.start-finish.start')} <strong>{startDateText}</strong></span>
+			<span>{$_('jam.common.start-finish.end')}<strong>{endDateText}</strong></span>
+			<small>({$_('jam.common.time-zone')} {timeZoneText})</small>
 		</div>
 	</PageSection>
-	<PageSection title="Prizes" id="prizes" isNarrow>
+	<PageSection title={$_('jam.newhorizons-jam.prizes.title')} id="prizes" isNarrow>
 		<div class="text-xl flex flex-col m-auto w-fit gap-4">
-			<span>🥇First place: <strong>$100</strong></span>
-			<span>🥈Second place: <strong>$75</strong></span>
-			<span>🥉Third place: <strong>$50</strong></span>
+			<span
+				>{$_('jam.common.podium.withcolumn.first')}
+				<strong>{$_('jam.newhorizons-jam.prizes.prizes.first')}</strong></span
+			>
+			<span
+				>{$_('jam.common.podium.withcolumn.second')}
+				<strong>{$_('jam.newhorizons-jam.prizes.prizes.second')}</strong></span
+			>
+			<span
+				>{$_('jam.common.podium.withcolumn.third')}
+				<strong>{$_('jam.newhorizons-jam.prizes.prizes.third')}</strong></span
+			>
 		</div>
 		<p>
-			Amounts in USD. All winners will also get a special role on <a class="link" href="#talk">
-				our Discord server
-			</a>. There will also be some extra Steam keys for winners or other participants, still to be
-			decided.
+			{$_('jam.newhorizons-jam.prizes.1')}
+			<a class="link" href="#talk">
+				{$_('jam.newhorizons-jam.prizes.2')}
+			</a>{$_('jam.newhorizons-jam.prizes.3')}
 		</p>
-		<p>Note: cash prizes will be given via PayPal only. No other methods will be supported.</p>
+		<p>
+			{$_('jam.newhorizons-jam.prizes.4')}
+		</p>
 	</PageSection>
-	<PageSection title="Rules" id="rules" isNarrow>
+	<PageSection title={$_('jam.newhorizons-jam.rules.title')} id="rules" isNarrow>
 		<p>
 			🌑 <strong>
-				Submissions must be an open source addon for
-				<a class="link" href="/mods/newhorizons"> New Horizons </a></strong
-			>.
+				{$_('jam.newhorizons-jam.rules.1')}
+				<a class="link" href="/mods/newhorizons"> {$_('general.newhorizons')} </a></strong
+			>{$_('jam.newhorizons-jam.rules.2')}
 		</p>
 		<p>
-			📜 <strong>No custom code</strong>. Submissions must use the basic New Horizons config dll.
-			That means you're limited to using the New Horizons JSON configs, XML text assets, and asset
-			bundles created in Unity, which can include custom textures, models, sounds, etc. Basically
-			everything New Horizons supports, except custom code.
+			📜 <strong>{$_('jam.newhorizons-jam.rules.3')}</strong>{$_('jam.newhorizons-jam.rules.4')}
 		</p>
 		<p>
-			🛤️ <strong>No extra dependencies</strong>. The mod you submit must only have one dependency:
-			New Horizons. It can not depend on any other mods.
+			🛤️ <strong>{$_('jam.newhorizons-jam.rules.5')}</strong>{$_('jam.newhorizons-jam.rules.6')}
 		</p>
 		<p>
 			⏱️ <strong>
-				There must be at least one release uploaded to GitHub within the jam deadline.
+				{$_('jam.newhorizons-jam.rules.7')}
 			</strong>
-			You can make as many releases as you want, but releases made outside the deadline won't be considered.
-			<u>Do not to overwrite releases, as this will change the upload date of that release.</u>
+			{$_('jam.newhorizons-jam.rules.8')}
+			<u>{$_('jam.newhorizons-jam.rules.9')}</u>
 		</p>
 		<p>
-			🙋 <strong>You can only contribute to one submission.</strong> You can't submit multiple mods,
-			or submit one mod solo and one in a team, or participate in multiple teams.
+			🙋 <strong>{$_('jam.newhorizons-jam.rules.10')}</strong>
+			{$_('jam.newhorizons-jam.rules.11')}
 		</p>
 		<p>
 			👮 <strong>
-				All submissions must follow the
+				{$_('jam.newhorizons-jam.rules.12')}
 				<a class="link" href="https://www.mobiusdigitalgames.com/fan-content-policy.html">
-					Mobius Digital Fan Content Policy
+					{$_('jam.newhorizons-jam.rules.13')}
 				</a>
-			</strong>.
+			</strong>{$_('jam.newhorizons-jam.rules.14')}
 		</p>
 		<p>
-			🛠️ <strong>You can use any assets you have a license to use.</strong> Besides using assets already
-			available in the game, you're allowed to use assets you find (models, textures, sounds, etc), but
-			you must be careful to understand and follow their licenses, just like you would in any open source
-			project. And of course, these assets must also follow the digital content policy mentioned above.
+			🛠️ <strong>{$_('jam.newhorizons-jam.rules.15')}</strong>
+			{$_('jam.newhorizons-jam.rules.16')}
 		</p>
 	</PageSection>
-	<PageSection title="Judging Criteria" id="criteria" isNarrow>
+	<PageSection title={$_('jam.newhorizons-jam.criteria.title')} id="criteria" isNarrow>
 		<p>
-			After the jam deadline has ended, we will play each submission and review them based on the
-			following criteria:
+			{$_('jam.newhorizons-jam.criteria.1')}
 		</p>
 		<p>
-			<strong>💭 How well does it follow the themes?</strong> There are two themes. You can chose to
-			follow one of the themes, or both. You won't be penalized for only following one theme. A submission
-			that only follows one theme really well can be as good as a submission that follows both themes
-			kinda well.
+			<strong>💭 {$_('jam.newhorizons-jam.criteria.2')}</strong>
+			{$_('jam.newhorizons-jam.criteria.3')}
 		</p>
 		<p>
-			<strong>💅 How polished is it?</strong> We will value quality over quantity. One highly polished
-			planet is better than 20 empty planets.
+			<strong>💅 {$_('jam.newhorizons-jam.criteria.4')}</strong>
+			{$_('jam.newhorizons-jam.criteria.5')}
 		</p>
 		<p>
-			<strong>🌑 How well does it leverage New Horizons?</strong> The point of the jam is to take NH
-			to its limits, so we will prefer submissions that take full advantage of what NH has to offer and
-			use it in creative ways. But again, quality over quantity: it's better to use a few features really
-			well, than trying to cramp all the features in there with no need for them.
+			<strong>🌑 {$_('jam.newhorizons-jam.criteria.6')}</strong>
+			{$_('jam.newhorizons-jam.criteria.7')}
 		</p>
 		<p>
-			<strong>🖼️ How well are the assets used?</strong> Whether you add your own custom assets (models,
-			textures, sounds, etc), or reuse the ones included in the game, they should fit the world they
-			are used in. We'll take into account the overall quality of the visuals/audio and how it all fits
-			together. So a highly detailed custom model with high resolution textures doesn't really mean anything
-			if everything around it doesn't follow the same standards.
+			<strong>🖼️ {$_('jam.newhorizons-jam.criteria.8')}</strong>
+			{$_('jam.newhorizons-jam.criteria.9')}
 		</p>
 		<p>
-			<strong>👤 Overall opinion.</strong> The judges are (allegedly) people, so the review process will
-			be mostly driven by personal opinion. The judging criteria are guidelines we'll use while reviewing
-			the submissions, they're not strict rules or values to be fed into a formula.
+			<strong>👤 {$_('jam.newhorizons-jam.criteria.10')}</strong>
+			{$_('jam.newhorizons-jam.criteria.11')}
 		</p>
 		<p>
-			These guidelines can change depending on how the jam is going. We might also take a shot at
-			community voting, if there are enough submissions to justify it and we can set up a good
-			system for it.
+			{$_('jam.newhorizons-jam.criteria.12')}
 		</p>
 	</PageSection>
-	<PageSection title="How to participate" id="how-to-participate" isNarrow>
+	<PageSection title={$_('jam.newhorizons-jam.participate.title')} id="how-to-participate" isNarrow>
 		<p class="bg-darker p-2 rounded">
-			<strong>TL;DR</strong>: Upload a New Horizons addon with <u>no custom code</u> during the jam
-			period, and give it the <code>jam</code> tag when submitting to the mod database.
+			<strong>{$_('jam.newhorizons-jam.participate.1')}</strong>{$_(
+				'jam.newhorizons-jam.participate.2'
+			)} <u>{$_('jam.newhorizons-jam.participate.3')}</u>
+			{$_('jam.newhorizons-jam.participate.4')}
+			<code>{$_('jam.newhorizons-jam.participate.5')}</code>
+			{$_('jam.newhorizons-jam.participate.6')}
 		</p>
 		<p>
-			To participate, you will need to submit a New Horizons addon to the Outer Wilds mod database. <a
-				class="link"
-				href="https://nh.outerwildsmods.com/tutorials/getting_started.html"
-			>
-				Read the New Horizon docs to learn how to make your addon
-			</a>.
+			{$_('jam.newhorizons-jam.participate.7')}
+			<a class="link" href="https://nh.outerwildsmods.com/tutorials/getting_started.html">
+				{$_('jam.newhorizons-jam.participate.8')}
+			</a>
 		</p>
 		<p>
-			<u>Your addon can not use custom code</u>. That means the only dll file in your mod should be
-			the <code>NewHorizonsConfig.dll</code> file that's included in the
+			<u>{$_('jam.newhorizons-jam.participate.9')}</u>
+			{$_('jam.newhorizons-jam.participate.10')}.
+			<code>NewHorizonsConfig.dll</code>
+			{$_('jam.newhorizons-jam.participate.11')}
 			<a class="link" href="https://github.com/Outer-Wilds-New-Horizons/nh-addon-template">
-				New Horizons Addon Template
-			</a>. You can, however, use
+				{$_('general.newhorizons-template')}
+			</a>{$_('jam.newhorizons-jam.participate.13')}
 			<a class="link" href="https://nh.outerwildsmods.com/tutorials/details.html#asset-bundles">
-				asset bundles
-			</a> to add custom content to your addon (models, textures, sounds, etc).
+				{$_('jam.newhorizons-jam.participate.14')}
+			</a>
+			{$_('jam.newhorizons-jam.participate.15')}
 		</p>
-		<h3>Use these tools to create your content</h3>
+		<h3>{$_('jam.newhorizons-jam.participate.16')}</h3>
 		<img alt="" src="/images/jam-edit.webp" />
 		<p>
-			The <a class="link" href="https://nh.outerwildsmods.com/tutorials/getting_started.html">
-				New Horizons Docs
+			{$_('jam.newhorizons-jam.participate.17')}
+			<a class="link" href="https://nh.outerwildsmods.com/tutorials/getting_started.html">
+				{$_('general.newhorizons-docs')}
 			</a>
-			explain in detail how to edit the required JSON files with editors like Visual Studio Code. But
-			you can also use the
+			{$_('jam.newhorizons-jam.participate.18')}
 			<a class="link" href="https://nh.outerwildsmods.com/editor.html">
-				New Horizons Config Editor App
-			</a>, which gives you a more friendly interface for creating, editing, and managing all of the
-			addon files.
+				{$_('jam.newhorizons-jam.participate.19')}
+			</a>{$_('jam.newhorizons-jam.participate.20')}
 		</p>
-		<h3>Upload a release within the deadline</h3>
+		<h3>{$_('jam.newhorizons-jam.participate.21')}</h3>
 		<img alt="" src="/images/jam-deadline.webp" />
 		<p>
-			If you're using the
+			{$_('jam.newhorizons-jam.participate.22')}
 			<a class="link" href="https://github.com/Outer-Wilds-New-Horizons/nh-addon-template">
-				New Horizons Addon Template
+				{$_('general.newhorizons-template')}
 			</a>
-			to create your addon (which you should), it will automatically create new addon releases when you
-			bump the version in your <code>manifest.json</code> file, as described in the
+			{$_('jam.newhorizons-jam.participate.23')}
+			<code>manifest.json</code>
+			{$_('jam.newhorizons-jam.participate.24')}
 			<a class="link" href="https://nh.outerwildsmods.com/tutorials/publishing.html">
-				New Horizons Docs
+				{$_('general.newhorizons-docs')}
 			</a>
 		</p>
 		<p>
-			You must upload a release of your addon within the jam deadline. It's OK if you submit the mod
-			to the database after the deadline is over, as long as a valid release was uploaded within the
-			deadline.
+			{$_('jam.newhorizons-jam.participate.25')}
 		</p>
 		<p>
-			⚠️ <u>Be careful not to overwrite releases</u>, as this would change the upload date. Always
-			upload new releases separately. If you're using the New Horizons template and letting it take
-			care of creating releases for you, then you shouldn't need to worry about this.
+			⚠️ <u>{$_('jam.newhorizons-jam.participate.26')}</u>{$_('jam.newhorizons-jam.participate.27')}
 		</p>
 		<p>
-			If you upload new releases to your jam mod after the deadline has passed, those releases will
-			be ignored. The most recent release that was uploaded within the deadline will be your
-			submission.
+			{$_('jam.newhorizons-jam.participate.28')}
 		</p>
-		<h3>Use the <code>jam</code> tag when submitting to the mod database</h3>
+		<h3>
+			{$_('jam.newhorizons-jam.participate.29')} <code>jam</code>
+			{$_('jam.newhorizons-jam.participate.30')}
+		</h3>
 		<img alt="" src="/images/jam-tag.webp" width={400} />
 		<p>
-			When you submit your addon to the database, you will need to include the <code>jam</code> tag,
-			together with any other tags that make sense for your addon. Every New Horizons addon
-			typically also has the <code>content</code> tag, since they add custom content to the game.
+			{$_('jam.newhorizons-jam.participate.31')} <code>jam</code>
+			{$_('jam.newhorizons-jam.participate.32')} <code>content</code>
+			{$_('jam.newhorizons-jam.participate.33')}
 		</p>
 	</PageSection>
-	<PageSection title="Teams" id="teams" isNarrow>
+	<PageSection title={$_('jam.newhorizons-jam.teams.title')} id="teams" isNarrow>
 		<p>
-			You are allowed to form teams as you wish. But we'd prefer for teams to be on the smaller size
-			(2-3 people), because otherwise we might not have enough submissions to make the jam
-			interesting.
+			{$_('jam.newhorizons-jam.teams.1')}
 		</p>
 		<p>
-			Prize rewards will be split equally among all team members, no exceptions. That means you will
-			get half the prize if you're on a two person team.
+			{$_('jam.newhorizons-jam.teams.2')}
 		</p>
 		<p>
-			If you're looking for a team, <a class="link" href="#talk">join our Discord</a> and ask around
-			there.
+			{$_('jam.newhorizons-jam.teams.3')}
+			<a class="link" href="#talk">{$_('jam.newhorizons-jam.teams.4')}</a>
+			{$_('jam.newhorizons-jam.teams.5')}
 		</p>
 	</PageSection>
-	<PageSection title="Talk to us" id="talk" isNarrow>
+	<PageSection title={$_('jam.newhorizons-jam.talk.title')} id="talk" isNarrow>
 		<p>
-			Join our Discord server if you have more questions, or just wanna discuss anything related to
-			the jam, modding, etc. We have a <code>#nh-jam</code> channel specifically for this. Also make
-			sure to go to the <code>#get-roles</code> channel and get the Jam role, so you can be notified
-			of jam updates.
+			{$_('jam.newhorizons-jam.talk.1')} <code>#nh-jam</code>
+			{$_('jam.newhorizons-jam.talk.2')}
+			<code>#get-roles</code>
+			{$_('jam.newhorizons-jam.talk.3')}
 		</p>
 		<DiscordLink />
 	</PageSection>

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,11 @@ import { sveltekit } from '@sveltejs/kit/vite';
 /** @type {import('vite').UserConfig} */
 const config = {
 	plugins: [sveltekit()],
+	server: {
+		fs: {
+			allow: [ `./locales` ]
+		}
+	}
 };
 
 export default config;


### PR DESCRIPTION
Solves #76 

Add support for i18n and integration on those pages:
- homepage
- history
- new horizons jam (jan 2023)
- error page

Also adds details to the README.

BREAKING CHANGE: Texts now need to be written in the ./locales folder. See the svelte-i18n docs.