### PR TITLE
Add Appstream URI to manager page

### DIFF
--- a/src/routes/mod-manager/+page.svelte
+++ b/src/routes/mod-manager/+page.svelte
@@ -181,10 +181,20 @@
 	</PageSection>
 	<PageSection title="More information" id="more-info" isNarrow>
 		<p>
-			For more information, check the{' '}
-			<a class="link" target="_blank" rel="noopener noreferrer" href={`${data.repoUrl}#readme`}>
-				readme on GitHub
-			</a>
+			If you need help, you can check <a
+				class="link"
+				href={`${data.repoUrl}/blob/main/owmods_gui/HELP.md`}
+				target="_blank"
+				rel="noopener">the FAQ file in the manager repo</a
+			>. Or you can come ask on
+			<a class="link" target="_blank" rel="noopener" href="https://discord.gg/9vE5aHxcF9"
+				>The Outer Wilds Modding Discord Server</a
+			>.
+		</p>
+		<p>
+			You can also check out the <a href={`${data.repoUrl}`} class="link"
+				>Mod Manager GitHub repository</a
+			>.
 		</p>
 	</PageSection>
 </PageContainer>

--- a/src/routes/mod-manager/+page.svelte
+++ b/src/routes/mod-manager/+page.svelte
@@ -41,6 +41,11 @@
 				<summary class="py-2 px-4 rounded link bg-darker justify-center h-full">For Linux</summary>
 				<div class="p-4 flex flex-col gap-2">
 					<div>
+						<CtaButton href="appstream:com.outerwildsmods.owmods_gui">
+							AppStream Link (Flatpak) (Use this on Steam Deck)
+						</CtaButton>
+					</div>
+					<div>
 						<CtaButton href={data.debUrl} isExternal icon={DebianIcon}>
 							Download .deb package for Debian
 						</CtaButton>
@@ -56,7 +61,7 @@
 							isExternal
 							icon={FlatpakIcon}
 						>
-							Flatpak for Linux (Steam Deck)
+							Flatpak for Linux
 						</CtaButton>
 					</div>
 					<div>


### PR DESCRIPTION
Adds a button that directly opens KDE discover for installing the manager, should help with steam deck installation.