### PR TITLE
Add "Popular New" to the home page

### DIFF
--- a/src/lib/components/mod-grid/mod-grid.svelte
+++ b/src/lib/components/mod-grid/mod-grid.svelte
@@ -34,7 +34,7 @@
 	let {
 		mods = [],
 		tagList = [],
-		defaultSortOrder = 'popular',
+		defaultSortOrder = 'installs',
 		tagBlockList = $bindable([]),
 		tagAllowList = $bindable([]),
 		allowFiltering = true,

--- a/src/lib/components/mod-grid/mod-grid.svelte
+++ b/src/lib/components/mod-grid/mod-grid.svelte
@@ -34,7 +34,7 @@
 	let {
 		mods = [],
 		tagList = [],
-		defaultSortOrder = 'hot',
+		defaultSortOrder = 'popular',
 		tagBlockList = $bindable([]),
 		tagAllowList = $bindable([]),
 		allowFiltering = true,

--- a/src/lib/helpers/mod-sorting.ts
+++ b/src/lib/helpers/mod-sorting.ts
@@ -5,13 +5,13 @@ export const sortOrderParamName = 'sortOrder' as const;
 
 export const sortOrders = {
 	installs: {
-		title: 'Popular',
+		title: 'Unique installs',
 		compareFunction: (modA: Mod, modB: Mod) => {
 			return modB.installCount - modA.installCount;
 		},
 	},
 	popularNew: {
-		title: 'Popular New',
+		title: 'Popular new',
 		compareFunction: (modA: Mod, modB: Mod) => {
 			let now = new Date();
 			function popularNewScore(mod: Mod) {

--- a/src/lib/helpers/mod-sorting.ts
+++ b/src/lib/helpers/mod-sorting.ts
@@ -4,10 +4,25 @@ import { recentViewsDayCount } from './constants';
 export const sortOrderParamName = 'sortOrder' as const;
 
 export const sortOrders = {
-	hot: {
-		title: 'Hot',
+	popular: {
+		title: 'Popular',
 		compareFunction: (modA: Mod, modB: Mod) => {
 			return modB.installCount - modA.installCount;
+		},
+	},
+	popularNew: {
+		title: 'Popular New',
+		compareFunction: (modA: Mod, modB: Mod) => {
+			let now = new Date();
+			function popularNewScore(mod: Mod) {
+				// A mod needs 2x the views to be hotter than a mod that is half its age
+				// Mods over a year old are ranked by installs
+				var age = (now.valueOf() - new Date(mod.firstReleaseDate).valueOf()) / (1000 * 60 * 60 * 24);
+				var score = age < 365 ? mod.installCount / Math.max(age, 7) : mod.installCount + Number.MIN_SAFE_INTEGER;
+				return score;
+			}
+
+			return popularNewScore(modB) - popularNewScore(modA);
 		},
 	},
 	mostDownloaded: {

--- a/src/lib/helpers/mod-sorting.ts
+++ b/src/lib/helpers/mod-sorting.ts
@@ -7,7 +7,20 @@ export const sortOrders = {
 	installs: {
 		title: 'Unique installs',
 		compareFunction: (modA: Mod, modB: Mod) => {
-			return modB.installCount - modA.installCount;
+			let now = new Date();
+			function uniqueInstallScore(mod: Mod) {
+				// Based on the "installs" this month and average downloads per month, calculate the ratio of "installs" to downloads
+				// An "install" is when you get the mod but not as a dependency or update
+				// Use this to extrapolate to installs of all time, since that isn't recorded (installCount should actually be labeled installCountThisMonth)
+				// The point of doing this over just using installCount this month is that it should in theory be representative of long term trends
+				var ageInMonths = (now.valueOf() - new Date(mod.firstReleaseDate).valueOf()) / Math.max(1000 * 60 * 60 * 24 * 30, 1);
+				var averageDownloadsPerMonth = mod.downloadCount / ageInMonths;
+				var ratioInstallsToDownloadsThisMonth = mod.installCount / averageDownloadsPerMonth;
+				var projectedInstallsAllTime = ratioInstallsToDownloadsThisMonth * mod.downloadCount;
+
+				return projectedInstallsAllTime;
+			}
+			return uniqueInstallScore(modB) - uniqueInstallScore(modA);
 		},
 	},
 	popularNew: {
@@ -17,6 +30,7 @@ export const sortOrders = {
 			function popularNewScore(mod: Mod) {
 				// A mod needs 2x the views to be hotter than a mod that is half its age
 				// Mods over a year old are ranked by installs
+				// Also this is installs this month for the record
 				var age = (now.valueOf() - new Date(mod.firstReleaseDate).valueOf()) / (1000 * 60 * 60 * 24);
 				var score = age < 365 ? mod.installCount / Math.max(age, 7) : mod.installCount + Number.MIN_SAFE_INTEGER;
 				return score;

--- a/src/lib/helpers/mod-sorting.ts
+++ b/src/lib/helpers/mod-sorting.ts
@@ -4,7 +4,7 @@ import { recentViewsDayCount } from './constants';
 export const sortOrderParamName = 'sortOrder' as const;
 
 export const sortOrders = {
-	popular: {
+	installs: {
 		title: 'Popular',
 		compareFunction: (modA: Mod, modB: Mod) => {
 			return modB.installCount - modA.installCount;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -23,11 +23,11 @@
 
 	const filteredModList = modList.filter((mod) => !mod.alpha);
 
-	const hotMods = sortModList(filteredModList, 'hot', modsPerCategory);
-	const newMods = sortModList(filteredModList, 'newest', modsPerCategory, hotMods);
+	const popularMods = sortModList(filteredModList, 'popular', modsPerCategory);
+	const hotNewMods = sortModList(filteredModList, 'popularNew', modsPerCategory, popularMods);
 	const updatedMods = sortModList(filteredModList, 'updated', modsPerCategory, [
-		...hotMods,
-		...newMods,
+		...popularMods,
+		...hotNewMods
 	]);
 </script>
 
@@ -62,8 +62,8 @@
 	</PageSection>
 	<PageSection id="mods" title="Some of our mods">
 		<div class="flex gap-8 text-center md:flex-row flex-col">
-			<FeaturedModSection title="Hot Mods" sortOrder="hot" mods={hotMods} />
-			<FeaturedModSection title="New Mods" sortOrder="newest" mods={newMods} />
+			<FeaturedModSection title="Popular Mods" sortOrder="popular" mods={popularMods} />
+			<FeaturedModSection title="Popular New Mods" sortOrder="popularNew" mods={hotNewMods} />
 			<FeaturedModSection title="Recently Updated" sortOrder="updated" mods={updatedMods} />
 		</div>
 	</PageSection>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -23,11 +23,11 @@
 
 	const filteredModList = modList.filter((mod) => !mod.alpha);
 
-	const popularMods = sortModList(filteredModList, 'popular', modsPerCategory);
-	const hotNewMods = sortModList(filteredModList, 'popularNew', modsPerCategory, popularMods);
+	const popularMods = sortModList(filteredModList, 'installs', modsPerCategory);
+	const popularNewMods = sortModList(filteredModList, 'popularNew', modsPerCategory, popularMods);
 	const updatedMods = sortModList(filteredModList, 'updated', modsPerCategory, [
 		...popularMods,
-		...hotNewMods
+		...popularNewMods
 	]);
 </script>
 
@@ -62,8 +62,8 @@
 	</PageSection>
 	<PageSection id="mods" title="Some of our mods">
 		<div class="flex gap-8 text-center md:flex-row flex-col">
-			<FeaturedModSection title="Popular Mods" sortOrder="popular" mods={popularMods} />
-			<FeaturedModSection title="Popular New Mods" sortOrder="popularNew" mods={hotNewMods} />
+			<FeaturedModSection title="Popular Mods" sortOrder="installs" mods={popularMods} />
+			<FeaturedModSection title="Popular New Mods" sortOrder="popularNew" mods={popularNewMods} />
 			<FeaturedModSection title="Recently Updated" sortOrder="updated" mods={updatedMods} />
 		</div>
 	</PageSection>

--- a/src/routes/mods/[mod]/+page.svelte
+++ b/src/routes/mods/[mod]/+page.svelte
@@ -21,7 +21,7 @@
 
 	const otherMods = sortModList(
 		modList.filter((otherMod) => otherMod.alpha == mod.alpha),
-		'hot',
+		'popular',
 		0
 	);
 

--- a/src/routes/mods/[mod]/+page.svelte
+++ b/src/routes/mods/[mod]/+page.svelte
@@ -21,7 +21,7 @@
 
 	const otherMods = sortModList(
 		modList.filter((otherMod) => otherMod.alpha == mod.alpha),
-		'popular',
+		'installs',
 		0
 	);
 


### PR DESCRIPTION
Etherpod and some other people were saying it'd make sense if "hot" mods were also new, so this.
- Renamed "hot" to "popular" because a mod being "hot" implies it is new, but age is not a factor.
- Added a new sorting for "popular new". This scores mods using installs divided by age, so a mod that is twice the age of another needs twice the downloads to score over it. Mods over a year old are put at the bottom and sorted by installs like in popular. 
- Removed "newest" mods from the home page since these mods would either appear as popular new or in recently updated.

<img width="1084" height="623" alt="image" src="https://github.com/user-attachments/assets/3dbd209a-d9b4-4e5b-a5ae-8c5321b1f3aa" />

With this we keep QSB and NomaiVR on the front page as they are the most popular and should always be there. Popular new currently has the most popular mod of the year, a popular recent jam winner, and the newest mod added to the DB. Seems pretty representative!

I'm open to changing the names, I find "popular" and "popular new" are best at accurately describing what these metrics are but I don't like how similar they are to each other. I'm not a fan of "hot" because it's unclear what it means.